### PR TITLE
Bump typescript version to ~5.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"colors": "^1.4.0",
 				"dotenv": "^8.2.0",
 				"ts-expose-internals": "=5.2.2",
-				"typescript": "~5.2.2"
+				"typescript": "~5.5.3"
 			},
 			"devDependencies": {
 				"@rbxts/types": "^1.0.428",
@@ -1688,9 +1688,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2978,9 +2978,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+			"version": "5.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
 		},
 		"uri-js": {
 			"version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"colors": "^1.4.0",
 		"dotenv": "^8.2.0",
 		"ts-expose-internals": "=5.2.2",
-		"typescript": "~5.2.2"
+		"typescript": "~5.5.3"
 	},
 	"devDependencies": {
 		"@rbxts/types": "^1.0.428",


### PR DESCRIPTION
Bump typescript version to ~5.5.3 to fix `You cannot use modules directly under node_modules` error in roblox-ts 3.0.